### PR TITLE
Order history - replace '0' with '-' on history analysis page

### DIFF
--- a/static/js/history.js
+++ b/static/js/history.js
@@ -116,6 +116,7 @@ function updateContactUI() {
       tmpBody += '</tr>';
     });
   }
+  tmpBody = tmpBody.replace(/<td>0/g,"<td>-");
   document.getElementById('contact-thead').innerHTML = tmpHead;
   document.getElementById('contact-tbody').innerHTML = tmpBody;
 }

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -116,7 +116,7 @@ function updateContactUI() {
       tmpBody += '</tr>';
     });
   }
-  tmpBody = tmpBody.replace(/<td>0/g,"<td>-");
+  tmpBody = tmpBody.replace(/<td>0/g, '<td>-');
   document.getElementById('contact-thead').innerHTML = tmpHead;
   document.getElementById('contact-tbody').innerHTML = tmpBody;
 }


### PR DESCRIPTION
在歷史點菜單銷售情況頁面，銷售數量為 0 的顯示為 "-" ，讓頁面變得較清楚易懂。